### PR TITLE
feat(tests): Add `TestSupport` trait and corresponding test suite for inaccessible properties and methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 Change Log
 ==========
 
-## 0.1.1 August 18, 2025
+## 0.2.0 August 18, 2025
 
 - Bug #11: Refactor project structure and update dependencies (@terabytesoftw)
+- Enh #12: Add `TestSupport` trait and corresponding test suite for inaccessible properties and methods (@terabytesoftw)
 
 ## 0.1.0 January 21, 2024
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Invoke inaccessible methods to expand testing coverage.
 
 ✅ **Cross-Platform String Assertions**
-- Eliminate false positives/negatives caused by windows vs. unix line ending differences.
+- Eliminate false positives/negatives caused by Windows vs. Unix line ending differences.
 - Normalize line endings for consistent string comparisons across platforms.
 
 ✅ **File System Test Management**

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Invoke inaccessible methods to expand testing coverage.
 
 ✅ **Cross-Platform String Assertions**
-- Eliminate false positives/negatives caused by Windows vs. Unix line ending differences.
+- Avoid false positives and negatives caused by Windows vs Unix line-ending differences.
 - Normalize line endings for consistent string comparisons across platforms.
 
 ✅ **File System Test Management**
@@ -190,7 +190,7 @@ final class SetInaccessiblePropertyTest extends TestCase
 {
     use TestSupport;
 
-    public function testSetProperty()
+    public function testSetProperty(): void
     {
         $object = new class () {
             private string $config = 'default';
@@ -201,7 +201,7 @@ final class SetInaccessiblePropertyTest extends TestCase
 
         $newValue = self::inaccessibleProperty($object, 'config');
 
-         self::assertSame('test-mode', $newValue, "Should set the inaccessible property to 'test-mode'.");
+        self::assertSame('test-mode', $newValue, "Should set the inaccessible property to 'test-mode'.");
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Invoke inaccessible methods to expand testing coverage.
 
 ✅ **Cross-Platform String Assertions**
-- Eliminate false positives/negatives caused by Windows vs. Unix line-ending differences.
+- Eliminate false positives/negatives caused by windows vs. unix line ending differences.
 - Normalize line endings for consistent string comparisons across platforms.
 
 ✅ **File System Test Management**
@@ -72,6 +72,33 @@ composer update
 ```
 
 ## Basic Usage
+
+### Using TestSupport trait
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use PHPForge\Support\TestSupport;
+use PHPUnit\Framework\TestCase;
+
+final class MyTest extends TestCase
+{
+    use TestSupport;
+
+    public function testInaccessibleProperty()
+    {
+        $object = new class () {
+            private string $secretValue = 'hidden';
+        };
+
+        $value = $this->inaccessibleProperty($object, 'secretValue');
+
+        self::assertSame('hidden', $value);
+    }
+}
+```
 
 ### Accessing private properties
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Invoke inaccessible methods to expand testing coverage.
 
 ✅ **Cross-Platform String Assertions**
-- Avoid false positives and negatives caused by Windows vs Unix line-ending differences.
+- Avoid false positives and negatives caused by Windows vs. Unix line ending differences.
 - Normalize line endings for consistent string comparisons across platforms.
 
 ✅ **File System Test Management**

--- a/README.md
+++ b/README.md
@@ -73,21 +73,20 @@ composer update
 
 ## Basic Usage
 
-### Using TestSupport trait
+### Accessing private properties
 
 ```php
 <?php
-
 declare(strict_types=1);
 
 use PHPForge\Support\TestSupport;
 use PHPUnit\Framework\TestCase;
 
-final class MyTest extends TestCase
+final class AccessPrivatePropertyTest extends TestCase
 {
     use TestSupport;
 
-    public function testInaccessibleProperty()
+    public function testInaccesibleProperty():void
     {
         $object = new class () {
             private string $secretValue = 'hidden';
@@ -95,93 +94,116 @@ final class MyTest extends TestCase
 
         $value = self::inaccessibleProperty($object, 'secretValue');
 
-        self::assertSame('hidden', $value);
+        self::assertSame('hidden', $value, "Should access the private property and return its value.");
     }
 }
-```
-
-### Accessing private properties
-
-```php
-<?php
-
-declare(strict_types=1);
-
-$object = new class () {
-    private string $secretValue = 'hidden';
-};
-
-// access private properties for testing
-$value = self::inaccessibleProperty($object, 'secretValue');
-
-self::assertSame('hidden', $value);
-```
-
-### Equals without line ending
-
-```php
-<?php
-
-declare(strict_types=1);
-
-// normalize line endings for consistent comparisons
-self::assertSame(
-    self::normalizeLineEndings("Foo\r\nBar"),
-    self::normalizeLineEndings("Foo\nBar"),
-    "Should match regardless of line ending style"
-);
 ```
 
 ### Invoking protected methods
 
 ```php
 <?php
-
 declare(strict_types=1);
 
-$object = new class () {
-    protected function calculate(int $a, int $b): int
+use PHPForge\Support\TestSupport;
+use PHPUnit\Framework\TestCase;
+
+final class InvokeProtectedMethodTest extends TestCase
+{
+    use TestSupport;
+
+    public function testInvokeMethod(): void
     {
-        return $a + $b;
+        $object = new class () {
+            protected function calculate(int $a, int $b): int
+            {
+                return $a + $b;
+            }
+        };
+
+        $result = self::invokeMethod($object, 'calculate', [5, 3]);
+
+        self::assertSame(8, $result, "Should invoke the protected method and return the correct sum.");
     }
-};
+}
+```
 
-// test protected method behavior
-$result = self::invokeMethod($object, 'calculate', [5, 3]);
+### Normalize line endings
 
-self::assertSame(8, $result);
+```php
+<?php
+declare(strict_types=1);
+
+use PHPForge\Support\TestSupport;
+use PHPUnit\Framework\TestCase;
+
+final class NormalizeLineEndingsTest extends TestCase
+{
+    use TestSupport;
+
+    public function testNormalizedComparison(): void
+    {
+        self::assertSame(
+            self::normalizeLineEndings("Foo\r\nBar"),
+            self::normalizeLineEndings("Foo\nBar"),
+            "Should match regardless of line ending style",
+        );
+    }
+}
 ```
 
 ### Remove files from directory
 
 ```php
 <?php
-
 declare(strict_types=1);
 
-$testDir = dirname(__DIR__) . '/runtime';
+use PHPForge\Support\TestSupport;
+use PHPUnit\Framework\TestCase;
 
-// clean up test artifacts (preserves '.gitignore' and '.gitkeep')
-self::removeFilesFromDirectory($testDir);
+final class RemoveFilesFromDirectoryTest extends TestCase
+{
+    use TestSupport;
+
+    public function testCleanup(): void
+    {
+        $testDir = dirname(__DIR__) . '/runtime';
+        // clean up test artifacts (preserves '.gitignore' and '.gitkeep')
+
+        self::removeFilesFromDirectory($testDir);
+
+        self::assertTrue(true, "Should remove all files in the test directory while preserving Git-tracked files.");
+    }
+}
 ```
 
 ### Set inaccessible property
 
 ```php
 <?php
-
 declare(strict_types=1);
 
-$object = new class () {
-    private string $config = 'default';
-};
+use PHPForge\Support\TestSupport;
+use PHPUnit\Framework\TestCase;
 
-// set private property for testing scenarios
-self::setInaccessibleProperty($object, 'config', 'test-mode');
+final class SetInaccessiblePropertyTest extends TestCase
+{
+    use TestSupport;
 
-$newValue = self::inaccessibleProperty($object, 'config');
+    public function testSetProperty()
+    {
+        $object = new class () {
+            private string $config = 'default';
+        };
 
-self::assertSame('test-mode', $newValue);
+        // set private property for testing scenarios
+        self::setInaccessibleProperty($object, 'config', 'test-mode');
+
+        $newValue = self::inaccessibleProperty($object, 'config');
+
+        self::assertSame('test-mode',  $newValue, "Should set the inaccessible property to 'test-mode'.");
+    }
+}
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ final class AccessPrivatePropertyTest extends TestCase
 {
     use TestSupport;
 
-    public function testInaccesibleProperty():void
+    public function testInaccessibleProperty(): void
     {
         $object = new class () {
             private string $secretValue = 'hidden';
@@ -201,7 +201,7 @@ final class SetInaccessiblePropertyTest extends TestCase
 
         $newValue = self::inaccessibleProperty($object, 'config');
 
-        self::assertSame('test-mode',  $newValue, "Should set the inaccessible property to 'test-mode'.");
+         self::assertSame('test-mode', $newValue, "Should set the inaccessible property to 'test-mode'.");
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 Install the extension.
 
 ```bash
-composer require --dev --prefer-dist php-forge/support:^0.1
+composer require --dev --prefer-dist php-forge/support:^0.2
 ```
 
 #### Method 2: Manual installation
@@ -60,7 +60,7 @@ Add to your `composer.json`.
 ```json
 {
     "require-dev": {
-        "php-forge/support": "^0.1"
+        "php-forge/support": "^0.2"
     }
 }
 ```
@@ -93,7 +93,7 @@ final class MyTest extends TestCase
             private string $secretValue = 'hidden';
         };
 
-        $value = $this->inaccessibleProperty($object, 'secretValue');
+        $value = self::inaccessibleProperty($object, 'secretValue');
 
         self::assertSame('hidden', $value);
     }
@@ -107,14 +107,12 @@ final class MyTest extends TestCase
 
 declare(strict_types=1);
 
-use PHPForge\Support\Assert;
-
 $object = new class () {
     private string $secretValue = 'hidden';
 };
 
 // access private properties for testing
-$value = Assert::inaccessibleProperty($object, 'secretValue');
+$value = self::inaccessibleProperty($object, 'secretValue');
 
 self::assertSame('hidden', $value);
 ```
@@ -126,12 +124,10 @@ self::assertSame('hidden', $value);
 
 declare(strict_types=1);
 
-use PHPForge\Support\Assert;
-
 // normalize line endings for consistent comparisons
-Assert::equalsWithoutLE(
-    "Foo\r\nBar",
-    "Foo\nBar",
+self::assertSame(
+    self::normalizeLineEndings("Foo\r\nBar"),
+    self::normalizeLineEndings("Foo\nBar"),
     "Should match regardless of line ending style"
 );
 ```
@@ -143,8 +139,6 @@ Assert::equalsWithoutLE(
 
 declare(strict_types=1);
 
-use PHPForge\Support\Assert;
-
 $object = new class () {
     protected function calculate(int $a, int $b): int
     {
@@ -153,7 +147,7 @@ $object = new class () {
 };
 
 // test protected method behavior
-$result = Assert::invokeMethod($object, 'calculate', [5, 3]);
+$result = self::invokeMethod($object, 'calculate', [5, 3]);
 
 self::assertSame(8, $result);
 ```
@@ -165,12 +159,10 @@ self::assertSame(8, $result);
 
 declare(strict_types=1);
 
-use PHPForge\Support\Assert;
-
 $testDir = dirname(__DIR__) . '/runtime';
 
 // clean up test artifacts (preserves '.gitignore' and '.gitkeep')
-Assert::removeFilesFromDirectory($testDir);
+self::removeFilesFromDirectory($testDir);
 ```
 
 ### Set inaccessible property
@@ -180,16 +172,14 @@ Assert::removeFilesFromDirectory($testDir);
 
 declare(strict_types=1);
 
-use PHPForge\Support\Assert;
-
 $object = new class () {
     private string $config = 'default';
 };
 
 // set private property for testing scenarios
-Assert::setInaccessibleProperty($object, 'config', 'test-mode');
+self::setInaccessibleProperty($object, 'config', 'test-mode');
 
-$newValue = Assert::inaccessibleProperty($object, 'config');
+$newValue = self::inaccessibleProperty($object, 'config');
 
 self::assertSame('test-mode', $newValue);
 ```

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.1-dev"
+            "dev-main": "0.3.x-dev"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "php-forge/support",
     "type": "library",
-    "description": "Support library tests for PHP",
+    "description": "Support utilities for enhanced testing capabilities.",
     "keywords": [
         "php",
         "php-forge",
@@ -11,16 +11,16 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^8.1",
-        "phpunit/phpunit": "^10.5"
+        "php": "^8.1"
     },
     "require-dev": {
         "infection/infection": "^0.27|^0.31",
         "maglnet/composer-require-checker": "^4.7",
-        "phpstan/phpstan-strict-rules": "^2.0.3",
-        "symplify/easy-coding-standard": "^12.5",
         "phpstan/phpstan": "^2.1",
-        "rector/rector": "^2.1"
+        "phpstan/phpstan-strict-rules": "^2.0.3",
+        "phpunit/phpunit": "^10.5",
+        "rector/rector": "^2.1",
+        "symplify/easy-coding-standard": "^12.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/TestSupport.php
+++ b/src/TestSupport.php
@@ -160,16 +160,16 @@ trait TestSupport
     }
 
     /**
-     * Normalizes line endings to unix style ('\n') for cross-platform string assertions.
+     * Normalizes line endings to Unix style ('\n') for cross-platform string assertions.
      *
-     * Converts windows style ('\r\n') line endings to unix style ('\n') to ensure consistent string comparisons across
+     * Converts Windows style ('\r\n') line endings to Unix style ('\n') to ensure consistent string comparisons across
      * different operating systems during testing.
      *
      * This method is useful for eliminating false negatives in assertions caused by platform-specific line endings.
      *
-     * @param string $line Input string potentially containing windows style line endings.
+     * @param string $line Input string potentially containing Windows style line endings.
      *
-     * @return string String with normalized unix style line endings.
+     * @return string String with normalized Unix style line endings.
      */
     public static function normalizeLineEndings(string $line): string
     {

--- a/src/TestSupport.php
+++ b/src/TestSupport.php
@@ -20,46 +20,20 @@ use function str_replace;
 use function unlink;
 
 /**
- * Assertion utility class for advanced test introspection and manipulation.
+ * Trait providing utilities for testing inaccessible properties, methods, and filesystem cleanup.
  *
- * Provides static helper methods for accessing and modifying inaccessible properties and methods invoking parent class
- * logic, and performing file system cleanup in test environments.
+ * Supplies static helper methods for normalizing line endings, accessing or modifying private/protected properties and
+ * methods (including those inherited from parent classes), invoking inaccessible methods, and recursively removing
+ * files from directories.
  *
- * Extends {@see \PHPUnit\Framework\Assert} to offer additional capabilities for testing private/protected members and
- * for managing test artifacts, supporting robust and isolated unit tests.
+ * These utilities are designed to facilitate comprehensive unit testing by enabling assertions and manipulations that
+ * would otherwise be restricted by visibility constraints or platform differences.
  *
- * Key features.
- * - Access and modify inaccessible (private/protected) properties and methods via reflection.
- * - Invoke parent class methods and properties for testing inheritance scenarios.
- * - Normalize line endings for cross-platform string assertions.
- * - Remove files and directories recursively for test environment cleanup.
- *
- * @copyright Copyright (C) 2025 PHPForge.
+ * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-final class Assert extends \PHPUnit\Framework\Assert
+trait TestSupport
 {
-    /**
-     * Asserts that two strings are equal after normalizing line endings to unix style ('\n').
-     *
-     * Replaces all windows style ('\r\n') line endings with unix style ('\n') in both the expected and actual strings
-     * before performing the equality assertion.
-     *
-     * This ensures cross-platform consistency in string comparisons where line ending differences may otherwise cause
-     * `false` negatives.
-     *
-     * @param string $expected Expected string value, with any line endings.
-     * @param string $actual Actual string value, with any line endings.
-     * @param string $message Optional failure message to display if the assertion fails. Default is an empty string.
-     */
-    public static function equalsWithoutLE(string $expected, string $actual, string $message = ''): void
-    {
-        $expected = str_replace("\r\n", "\n", $expected);
-        $actual = str_replace("\r\n", "\n", $actual);
-
-        self::assertEquals($expected, $actual, $message);
-    }
-
     /**
      * Retrieves the value of an inaccessible property from a parent class instance.
      *
@@ -183,6 +157,23 @@ final class Assert extends \PHPUnit\Framework\Assert
         }
 
         return $result ?? null;
+    }
+
+    /**
+     * Normalizes line endings to unix style ('\n') for cross-platform string assertions.
+     *
+     * Converts windows style ('\r\n') line endings to unix style ('\n') to ensure consistent string comparisons across
+     * different operating systems during testing.
+     *
+     * This method is useful for eliminating false negatives in assertions caused by platform-specific line endings.
+     *
+     * @param string $line Input string potentially containing windows style line endings.
+     *
+     * @return string String with normalized unix style line endings.
+     */
+    public static function normalizeLineEndings(string $line): string
+    {
+        return str_replace("\r\n", "\n", $line);
     }
 
     /**

--- a/src/TestSupport.php
+++ b/src/TestSupport.php
@@ -173,7 +173,7 @@ trait TestSupport
      */
     public static function normalizeLineEndings(string $line): string
     {
-        return str_replace("\r\n", "\n", $line);
+        return str_replace(["\r\n", "\r"], "\n", $line);
     }
 
     /**

--- a/tests/TestSupportTest.php
+++ b/tests/TestSupportTest.php
@@ -4,41 +4,35 @@ declare(strict_types=1);
 
 namespace PHPForge\Support\Tests;
 
-use PHPForge\Support\Assert;
 use PHPForge\Support\Tests\Stub\{TestBaseClass, TestClass};
+use PHPForge\Support\TestSupport;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use RuntimeException;
 
 /**
- * Test suite for {@see Assert} utility methods and reflection helpers.
+ * Test suite for {@see TestSupport} trait utility methods.
  *
- * Verifies the behavior of assertion and reflection-based utility methods for testing inaccessible properties, parent
- * properties, and methods, as well as file system operations for test directories.
+ * Verifies the behavior of utility methods provided by the {@see TestSupport} trait for testing inaccessible
+ * properties, parent properties, and methods, as well as file system operations for test directories.
  *
  * These tests ensure correct access and mutation of private/protected members, invocation of inaccessible methods, and
  * robust file removal logic, including error handling for non-existent directories.
  *
- * Test coverage.
+ * Test coverage:
  * - Accessing and asserting values of inaccessible properties and parent properties.
  * - Ensuring correct exception handling for invalid operations.
  * - Invoking inaccessible methods and parent methods.
+ * - Normalizing line endings.
  * - Removing files from directories and handling missing directories.
  * - Setting values for inaccessible properties and parent properties.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-final class AssertTest extends TestCase
+final class TestSupportTest extends TestCase
 {
-    public function testEqualsWithoutLEReturnsTrueWhenStringsAreIdenticalWithLineEndings(): void
-    {
-        Assert::equalsWithoutLE(
-            "foo\r\nbar",
-            "foo\r\nbar",
-            "Should return 'true' when both strings are identical including line endings.",
-        );
-    }
+    use TestSupport;
 
     /**
      * @throws ReflectionException
@@ -47,12 +41,21 @@ final class AssertTest extends TestCase
     {
         self::assertSame(
             'valueParent',
-            Assert::inaccessibleParentProperty(
+            self::inaccessibleParentProperty(
                 new TestClass(),
                 TestBaseClass::class,
                 'propertyParent',
             ),
             "Should return the value of the parent property 'propertyParent' when accessed via reflection.",
+        );
+    }
+
+    public function testNormalizeLineEndingsWhenStringsAreIdenticalWithLineEndings(): void
+    {
+        self::assertSame(
+            self::normalizeLineEndings("foo\r\nbar"),
+            self::normalizeLineEndings("foo\r\nbar"),
+            "Should return 'true' when both strings are identical including line endings.",
         );
     }
 
@@ -64,7 +67,7 @@ final class AssertTest extends TestCase
         touch("{$dir}/test.txt");
         touch("{$dir}/subdir/test.txt");
 
-        Assert::removeFilesFromDirectory($dir);
+        self::removeFilesFromDirectory($dir);
 
         $this->assertFileDoesNotExist(
             "{$dir}/test.txt",
@@ -83,7 +86,7 @@ final class AssertTest extends TestCase
     {
         self::assertSame(
             'value',
-            Assert::inaccessibleProperty(new TestClass(), 'property'),
+            self::inaccessibleProperty(new TestClass(), 'property'),
             "Should return the value of the private property 'property' when accessed via reflection.",
         );
     }
@@ -95,7 +98,7 @@ final class AssertTest extends TestCase
     {
         $this->assertSame(
             'value',
-            Assert::invokeMethod(new TestClass(), 'inaccessibleMethod'),
+            self::invokeMethod(new TestClass(), 'inaccessibleMethod'),
             "Should return 'value' when invoking the inaccessible method 'inaccessibleParentMethod' on 'TestClass' " .
             'via reflection.',
         );
@@ -108,7 +111,7 @@ final class AssertTest extends TestCase
     {
         $this->assertSame(
             'valueParent',
-            Assert::invokeParentMethod(
+            self::invokeParentMethod(
                 new TestClass(),
                 TestBaseClass::class,
                 'inaccessibleParentMethod',
@@ -125,11 +128,11 @@ final class AssertTest extends TestCase
     {
         $object = new TestClass();
 
-        Assert::setInaccessibleParentProperty($object, TestBaseClass::class, 'propertyParent', 'foo');
+        self::setInaccessibleParentProperty($object, TestBaseClass::class, 'propertyParent', 'foo');
 
         $this->assertSame(
             'foo',
-            Assert::inaccessibleParentProperty($object, TestBaseClass::class, 'propertyParent'),
+            self::inaccessibleParentProperty($object, TestBaseClass::class, 'propertyParent'),
             "Should return 'foo' after setting the parent property 'propertyParent' via " .
             "'setInaccessibleParentProperty' method.",
         );
@@ -142,11 +145,11 @@ final class AssertTest extends TestCase
     {
         $object = new TestClass();
 
-        Assert::setInaccessibleProperty($object, 'property', 'foo');
+        self::setInaccessibleProperty($object, 'property', 'foo');
 
         $this->assertSame(
             'foo',
-            Assert::inaccessibleProperty($object, 'property'),
+            self::inaccessibleProperty($object, 'property'),
             "Should return 'foo' after setting the private property 'property' via 'setInaccessibleProperty' method.",
         );
     }
@@ -156,6 +159,6 @@ final class AssertTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to open directory: non-existing-directory');
 
-        Assert::removeFilesFromDirectory(__DIR__ . '/non-existing-directory');
+        self::removeFilesFromDirectory(__DIR__ . '/non-existing-directory');
     }
 }

--- a/tests/TestSupportTest.php
+++ b/tests/TestSupportTest.php
@@ -55,7 +55,7 @@ final class TestSupportTest extends TestCase
         self::assertSame(
             self::normalizeLineEndings("foo\r\nbar"),
             self::normalizeLineEndings("foo\nbar"),
-            "Should produce the same normalized string for CRLF and LF inputs.",
+            'Should produce the same normalized string for CRLF and LF inputs.',
         );
     }
 

--- a/tests/TestSupportTest.php
+++ b/tests/TestSupportTest.php
@@ -55,7 +55,7 @@ final class TestSupportTest extends TestCase
         self::assertSame(
             self::normalizeLineEndings("foo\r\nbar"),
             self::normalizeLineEndings("foo\nbar"),
-            'Should produce the same normalized string for CRLF and LF inputs.',
+            "Should produce the same normalized string for 'CRLF' and 'LF' inputs.",
         );
     }
 

--- a/tests/TestSupportTest.php
+++ b/tests/TestSupportTest.php
@@ -54,8 +54,8 @@ final class TestSupportTest extends TestCase
     {
         self::assertSame(
             self::normalizeLineEndings("foo\r\nbar"),
-            self::normalizeLineEndings("foo\r\nbar"),
-            "Should return 'true' when both strings are identical including line endings.",
+            self::normalizeLineEndings("foo\nbar"),
+            "Should produce the same normalized string for CRLF and LF inputs.",
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a utility to normalize line endings (CRLF → LF).

- Refactor
  - Migrated public testing utilities from class/static style to trait-style usage.
  - Replaced the combined line-ending+assertion helper with a standalone normalizer.

- Documentation
  - Updated README examples and wording to show trait-based usage; bumped sample version and changelog.

- Tests
  - Updated tests to use the trait-style API and added coverage for line-ending normalization.

- Chores
  - Moved testing framework to dev-dependencies, updated dev tooling and branch alias, and revised package description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->