### PR TITLE
fix(docs): Clarify parameter descriptions in `Message::getMessage()` method in `Message` enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.1 Under development
 
 - Bug #14: Update descriptions in stub classes to clarify purpose (@terabytesoftw)
+- Bug #15: Clarify parameter descriptions in `Message::getMessage()` method in `Message` enum (@terabytesoftw)
 
 ## 0.3.0 January 19, 2026
 

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -41,11 +41,9 @@ enum Message: string
     /**
      * Returns the formatted message string for the error case.
      *
-     * Retrieves and formats the error message string by interpolating the provided arguments.
+     * @param int|string ...$argument Values to insert into the message template.
      *
-     * @param int|string ...$argument Dynamic arguments to insert into the message.
-     *
-     * @return string Error message with interpolated arguments.
+     * @return string Formatted error message with interpolated arguments.
      *
      * Usage example:
      * ```php


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
